### PR TITLE
logo in chrome shouldn't stretch

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -23,6 +23,7 @@ body {
 #logo_image {
   min-width: 250px;
   max-width: 27vw;
+  max-height: 27vh;
   width: 100%;
 }
 


### PR DESCRIPTION
added vh to a max-height in the css file.   
